### PR TITLE
Add support for RDF::Raptor::NTriples.serialize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 
 group :debug do
   gem 'pry'
-  gem 'byebug', platforms: :mri
+  gem 'pry-byebug', platforms: :mri
 end
 
 platforms :rbx do

--- a/lib/rdf/raptor/ffi.rb
+++ b/lib/rdf/raptor/ffi.rb
@@ -179,6 +179,23 @@ module RDF::Raptor
       # @return [V2::Serializer]
       attr_reader :serializer
 
+      def self.serialize(value)
+        output = StringIO.new
+        writer = new(output)
+        case value
+        when nil then nil
+        when FalseClass then value.to_s
+        when RDF::Statement
+          writer.write_triple(statement.subject, statement.predicate, statement.object)
+        when RDF::Term
+          writer.write_term(value)
+        else
+          raise ArgumentError, "expected an RDF::Statement or RDF::Term, but got #{value.inspect}"
+        end
+
+        output.to_s
+      end
+
       ##
       # @param  [RDF::Resource] subject
       # @param  [RDF::URI]      predicate
@@ -187,6 +204,10 @@ module RDF::Raptor
       # @see    RDF::Writer#write_triple
       def write_triple(subject, predicate, object)
         @serializer.serialize_triple(subject, predicate, object)
+      end
+
+      def write_term(value)
+        raise NotImplementedError
       end
 
       ##

--- a/lib/rdf/raptor/ffi/v2.rb
+++ b/lib/rdf/raptor/ffi/v2.rb
@@ -28,6 +28,7 @@ module RDF::Raptor::FFI
     # @see http://librdf.org/raptor/api/tutorial-initialising-finishing.html
     typedef :pointer, :raptor_world
     typedef :int, :raptor_version
+    typedef :pointer, :raptor_iostream
     attach_function :raptor_new_world_internal, [:raptor_version], :raptor_world
     attach_function :raptor_free_world, [], :void
     attach_function :raptor_alloc_memory, [:size_t], :pointer
@@ -77,6 +78,7 @@ module RDF::Raptor::FFI
     attach_function :raptor_new_term_from_literal, [:raptor_world, :literal, :datatype, :language], :raptor_term
     attach_function :raptor_new_term_from_blank, [:raptor_world, :blank], :raptor_term
     attach_function :raptor_free_term, [:raptor_term], :void
+    attach_function :raptor_term_ntriples_write, [:raptor_term, :raptor_iostream], :int
 
     # @see http://librdf.org/raptor/api/raptor2-section-xml-namespace.html
     typedef :pointer, :raptor_namespace
@@ -106,7 +108,6 @@ module RDF::Raptor::FFI
     attach_function :raptor_free_parser, [:raptor_parser], :void
 
     # @see http://librdf.org/raptor/api/raptor2-section-iostream.html
-    typedef :pointer, :raptor_iostream
     attach_function :raptor_new_iostream_from_handler, [:raptor_world, :pointer, :pointer], :raptor_iostream
     attach_function :raptor_new_iostream_to_filename, [:raptor_world, :string], :raptor_iostream
     attach_function :raptor_new_iostream_to_sink, [:raptor_world], :raptor_iostream

--- a/lib/rdf/raptor/ffi/v2/serializer.rb
+++ b/lib/rdf/raptor/ffi/v2/serializer.rb
@@ -7,6 +7,8 @@ module RDF::Raptor::FFI::V2
   class Serializer < ::FFI::ManagedStruct
     include RDF::Raptor::FFI
 
+    attr_reader :iostream
+
     # Note this layout is private
     layout  :world, :pointer,
             :locator, :pointer,

--- a/lib/rdf/raptor/ntriples.rb
+++ b/lib/rdf/raptor/ntriples.rb
@@ -86,7 +86,12 @@ module RDF::Raptor
     #   end
     #
     class Writer < RDF::Raptor::Writer
+      include RDF::Raptor::FFI
       format RDF::Raptor::NTriples::Format
+
+      def write_term(value)
+        V2.raptor_term_ntriples_write(value, @serializer.iostream)
+      end
     end # Writer
   end # NTriples
 end # RDF::Raptor

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 
 begin
   require 'pry'
+  require 'pry-byebug'
 rescue LoadError
 end
 


### PR DESCRIPTION
This fixes compatibility with the latest version of `RDF`.