### PR TITLE
Add raptor_world arg to FFI definition for func raptor_free_world (instead of no args)

### DIFF
--- a/lib/rdf/raptor/ffi/v2.rb
+++ b/lib/rdf/raptor/ffi/v2.rb
@@ -30,7 +30,7 @@ module RDF::Raptor::FFI
     typedef :int, :raptor_version
     typedef :pointer, :raptor_iostream
     attach_function :raptor_new_world_internal, [:raptor_version], :raptor_world
-    attach_function :raptor_free_world, [], :void
+    attach_function :raptor_free_world, [:raptor_world], :void
     attach_function :raptor_alloc_memory, [:size_t], :pointer
     attach_function :raptor_calloc_memory, [:size_t, :size_t], :pointer
     attach_function :raptor_free_memory, [:pointer], :void


### PR DESCRIPTION
The underlying c library seems to accept a pointer to a raptor_world object, whereas the FFI defines no args to this function.

Here is the library definition:
https://github.com/dajobe/raptor/blob/e4285aefef442da7e4e847dfd77097a40506773f/src/raptor2.h.in#L1051
```
void raptor_free_world(raptor_world* world);
```

But here we have no args defined:
https://github.com/ruby-rdf/rdf-raptor/blob/76411d511d9d81b49eb99657a12e61ebe18e0cfc/lib/rdf/raptor/ffi/v2.rb#L33

Please see this issue for more detailed explanation:
https://github.com/ruby-rdf/rdf-raptor/issues/27

Fixes #27.